### PR TITLE
Backport newer versions of py-packages

### DIFF
--- a/environments/CMSSW_12_1_X/spack.yaml
+++ b/environments/CMSSW_12_1_X/spack.yaml
@@ -300,6 +300,8 @@ spack:
   - py-atomicwrites@1.4.0
   - py-attrs@21.2.0
   - py-autopep8@1.6.0
+  - py-avro@1.11.0
+  - py-awkward@1.8.0
   - py-backcall@0.2.0
   - py-backports-entry-points-selectable@1.1.0
   - py-beautifulsoup4@4.10.0
@@ -352,6 +354,8 @@ spack:
   - py-flake8@4.0.1
   - py-flatbuffers@2.0
   - py-flawfinder@2.0.19
+  - py-fonttools@4.31.2
+  - py-frozenlist@1.3.0
   - py-flit@3.3.0
   - py-flit-core@3.3.0
   - py-fs@0.5.4
@@ -384,6 +388,7 @@ spack:
   - py-ipykernel@6.4.1
   - py-ipython@7.28.0
   - py-ipython-genutils@0.2.0  # NB: Not in cms, needed for almost all ipy/jupy packages
+  - py-ipywidgets@7.7.0
   - py-isort@5.9.3
   - py-jedi@0.18.0
   - py-jinja2@3.0.1
@@ -393,11 +398,13 @@ spack:
   - py-jsonpickle@2.0.0
   - py-jsonschema@3.2.0
   - py-jupyter-client@7.0.6
+  - py-jupyter-console@6.4.3
   - py-jupyter-core@4.7.1
   - py-jupyter-packaging@0.10.6
   - py-jupyter-server@1.11.2
   - py-jupyter-server-mathjax@0.2.3
   - py-jupyterlab-pygments@0.1.2
+  - py-jupyterlab-widgets@1.1.0
   - py-pyjwt@2.1.0
   - py-keras2onnx@1.7.0
   - py-keras-applications@1.0.8

--- a/repos/backport/packages/py-avro/package.py
+++ b/repos/backport/packages/py-avro/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyAvro(PythonPackage):
+    """Avro is a serialization and RPC framework."""
+
+    homepage = "https://avro.apache.org/docs/current/"
+    pypi = "avro/avro-1.8.2.tar.gz"
+
+    version('1.11.0', sha256='1206365cc30ad561493f735329857dd078533459cee4e928aec2505f341ce445')
+    version('1.10.2', sha256='381b990cc4c4444743c3297348ffd46e0c3a5d7a17e15b2f4a9042f6e955c31a')
+    version('1.8.2', sha256='8f9ee40830b70b5fb52a419711c9c4ad0336443a6fba7335060805f961b04b59')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('python@2.7:', type=('build', 'run'))

--- a/repos/backport/packages/py-awkward/package.py
+++ b/repos/backport/packages/py-awkward/package.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyAwkward(PythonPackage):
+    """Manipulate JSON-like data with NumPy-like idioms."""
+
+    git = "https://github.com/scikit-hep/awkward-1.0.git"
+    pypi = "awkward/awkward-1.1.2.tar.gz"
+    homepage = "https://awkward-array.org"
+
+    maintainers = ['vvolkl']
+
+    version('master', branch='master')
+    version('1.8.0', sha256='6655fa22d1b1d1dcb9ccee0d502350ab90c53467a10b540b7624422b594d2e72')
+    version('1.7.0', sha256='e4e642dfe496d2acb245c90e37dc18028e25d5e936421e7371ea6ba0fde6435a')
+    version('1.5.1', sha256='c0357c62223fefcfc7a7565389dbd4db900623bf10eccf2bc8e87586ec59b38d')
+    version('1.5.0', sha256='3cb1b0e28f420232d894d89665d5c0c8241b99e56d806171f4faf5cdfec08ae1')
+    version('1.4.0', sha256='25ae6114d5962c717cb87e3bc30a2f6eaa232b252cf8c51ba805b8f04664ae0d')
+    version('1.3.0', sha256='b6021694adec9813842bad1987b837e439dabaf5b0dff9041201d238fca71fb4')
+    version('1.2.3', sha256='7d727542927a926f488fa62d04e2c5728c72660f17f822e627f349285f295063')
+    version('1.2.2', sha256='89f126a072d3a6eee091e1afeed87e0b2ed3c34ed31a1814062174de3cab8d9b')
+    version('1.1.2', sha256='4ae8371d9e6d5bd3e90f3686b433cebc0541c88072655d2c75ec58e79b5d6943')
+    version('1.0.2', sha256='3468cb80cab51252a1936e5e593c7df4588ea0e18dcb6fb31e3d2913ba883928')
+
+    patch('pybind11.patch', when="@:1.2.2")
+    patch('pybind11_02.patch', when="@1.2.3:")
+
+    depends_on('py-setuptools@42.0:', type=('build', 'run'))
+    depends_on('py-pyyaml', type='build')
+
+    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
+    depends_on('py-numpy@1.13.1:', type=('build', 'run'))
+    depends_on('py-pybind11', type=('build', 'link'))
+    depends_on('dlpack', when="@1.0.0:")
+    depends_on('rapidjson@:1.1.0')
+    depends_on('cmake@3.13:', type='build')
+    depends_on('py-wheel@0.36.0:', type='build', when='@:1.7.0')

--- a/repos/backport/packages/py-awkward/pybind11.patch
+++ b/repos/backport/packages/py-awkward/pybind11.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fedfe3a..bf762c9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -107,7 +107,7 @@ addtest(test0074 tests/test_0074-argsort-and-sort-rawarray.cpp)
+ 
+ # Third tier: Python modules.
+ if (PYBUILD)
+-  add_subdirectory(pybind11)
++  find_package(pybind11)
+ 
+   file(GLOB LAYOUT_SOURCES "src/python/*.cpp")
+   pybind11_add_module(_ext ${LAYOUT_SOURCES})
+

--- a/repos/backport/packages/py-awkward/pybind11_02.patch
+++ b/repos/backport/packages/py-awkward/pybind11_02.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ba2c37f..bd7f268 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -96,7 +96,7 @@ option(PYBUILD "Build Python modules")
+ 
+ # Third tier: Python modules.
+ if(PYBUILD)
+-  add_subdirectory(pybind11)
++  find_package(pybind11)
+ 
+   file(GLOB LAYOUT_SOURCES "src/python/*.cpp")
+   pybind11_add_module(_ext ${LAYOUT_SOURCES})
+

--- a/repos/backport/packages/py-fonttools/package.py
+++ b/repos/backport/packages/py-fonttools/package.py
@@ -16,10 +16,13 @@ class PyFonttools(PythonPackage):
     homepage = "https://github.com/fonttools/fonttools"
     pypi     = "fonttools/fonttools-4.28.1.zip"
 
+    version('4.31.2', sha256='236b29aee6b113e8f7bee28779c1230a86ad2aac9a74a31b0aedf57e7dfb62a4')
     version('4.29.1', sha256='2b18a172120e32128a80efee04cff487d5d140fe7d817deb648b2eee023a40e4')
     version('4.28.1', sha256='8c8f84131bf04f3b1dcf99b9763cec35c347164ab6ad006e18d2f99fcab05529')
+    version('4.26.2', sha256='c1c0e03dd823e9e905232e875ea02dbb2dcd2ba195418c6d11bfaea49b9c774d')
 
-    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('python@3.7:', when='@4.28:', type=('build', 'run'))
+    depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
 
     @property

--- a/repos/backport/packages/py-frozenlist/package.py
+++ b/repos/backport/packages/py-frozenlist/package.py
@@ -13,6 +13,7 @@ class PyFrozenlist(PythonPackage):
     homepage = "https://github.com/aio-libs/frozenlist"
     pypi     = "frozenlist/frozenlist-1.2.0.tar.gz"
 
+    version('1.3.0', sha256='ce6f2ba0edb7b0c1d8976565298ad2deba6f8064d2bebb6ffce2ca896eb35b0b')
     version('1.2.0', sha256='68201be60ac56aff972dc18085800b6ee07973c49103a8aba669dee3d71079de')
 
     depends_on('python@3.6:', type=('build', 'run'))

--- a/repos/backport/packages/py-ipywidgets/package.py
+++ b/repos/backport/packages/py-ipywidgets/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyIpywidgets(PythonPackage):
+    """IPython widgets for the Jupyter Notebook"""
+
+    homepage = "https://github.com/ipython/ipywidgets"
+    pypi = "ipywidgets/ipywidgets-7.6.5.tar.gz"
+
+    version('7.7.0', sha256='ab4a5596855a88b83761921c768707d65e5847068139bc1729ddfe834703542a')
+    version('7.6.5', sha256='00974f7cb4d5f8d494c19810fedb9fa9b64bffd3cda7c2be23c133a1ad3c99c5')
+    version('7.6.3', sha256='9f1a43e620530f9e570e4a493677d25f08310118d315b00e25a18f12913c41f0')
+    version('7.5.1', sha256='e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97')
+    version('7.4.2', sha256='a3e224f430163f767047ab9a042fc55adbcab0c24bbe6cf9f306c4f89fdf0ba3')
+    version('5.2.2', sha256='baf6098f054dd5eacc2934b8ea3bef908b81ca8660d839f1f940255a72c660d2')
+
+    depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
+    # pip silently replaces distutils with setuptools
+    depends_on('py-setuptools', type='build')
+    depends_on('py-ipython@4:', type=('build', 'run'))
+    depends_on('py-ipython@4:5', type=('build', 'run'), when='^python@:3.2')
+    depends_on('py-jupyterlab-widgets@1.0.0:', type=('build', 'run'),
+               when='^python@3.6:')
+    depends_on('py-ipykernel@4.2.2:', type=('build', 'run'))
+    depends_on('py-ipykernel@4.5.1:', type=('build', 'run'), when='@6:')
+    depends_on('py-ipython-genutils@0.2.0:0.2', type=('build', 'run'),
+               when='@7.6.4:')
+    depends_on('py-traitlets@4.2.1:', type=('build', 'run'))
+    depends_on('py-traitlets@4.3.1:', type=('build', 'run'), when='@6:')
+    depends_on('py-nbformat@4.2.0:', type=('build', 'run'), when='@6:')
+    depends_on('py-widgetsnbextension@1.2.6:1.9', type=('build', 'run'),
+               when='@5.2.2')
+    depends_on('py-widgetsnbextension@3.4.0:3.4', type=('build', 'run'),
+               when='@7.4.2')
+    depends_on('py-widgetsnbextension@3.5.0:3.5', type=('build', 'run'),
+               when='@7.5.1:7.6.5')
+    depends_on('py-widgetsnbextension@3.6', type=('build', 'run'),
+               when='@7.7:')

--- a/repos/backport/packages/py-jupyter-console/package.py
+++ b/repos/backport/packages/py-jupyter-console/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyJupyterConsole(PythonPackage):
+    """Jupyter Terminal Console"""
+
+    homepage = "https://github.com/jupyter/jupyter_console"
+    pypi     = "jupyter_console/jupyter_console-6.4.0.tar.gz"
+
+    version('6.4.3', sha256='55f32626b0be647a85e3217ddcdb22db69efc79e8b403b9771eb9ecc696019b5')
+    version('6.4.0', sha256='242248e1685039cd8bff2c2ecb7ce6c1546eb50ee3b08519729e6e881aec19c7')
+    version('6.1.0', sha256='6f6ead433b0534909df789ea64f0a14cdf9b6b2360757756f08182be4b9e431b')
+    version('5.2.0', sha256='545dedd3aaaa355148093c5609f0229aeb121b4852995c2accfa64fe3e0e55cd')
+    version('5.0.0', sha256='7ddfc8cc49921b0ed852500928922e637f9188358c94b5c76339a5a8f9ac4c11')
+    version('4.1.1', sha256='d754cfd18d258fa9e7dde39a36e589c4a7241075b5d0f420691fa3d50e4c4ae3')
+    version('4.1.0', sha256='3f9703b632e38d68713fc2ea1f546edc4db2a8f925c94b6dd91a8d0c13816ce9')
+    version('4.0.3', sha256='555be6963a8f6431fbe1d424c7ffefee90824758058e4c9a2ab3aa045948eb85')
+    version('4.0.2', sha256='97e27e1c27a6dd04d166b7a4c81d717becdd979a0879a628e08f295a43a2bc58')
+
+    depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
+    depends_on('python@3.5:', type=('build', 'run'), when='@6:')
+    depends_on('python@3.6:', type=('build', 'run'), when='@6.2:')
+    depends_on('py-setuptools@40.8.0:', type='build', when='@6.2:')
+    depends_on('py-jupyter-client@7.0.0:', type=('build', 'run'), when='@6.4.3:')
+    depends_on('py-jupyter-client', type=('build', 'run'))
+    depends_on('py-ipython@:5.8.0', type=('build', 'run'), when='@:5')
+    depends_on('py-ipython', type=('build', 'run'))
+    depends_on('py-ipykernel', type=('build', 'run'))
+    depends_on('py-pygments', type=('build', 'run'))
+    depends_on('py-prompt-toolkit@1.0.0:1', type=('build', 'run'), when='@:5')
+    depends_on('py-prompt-toolkit@2.0.0:2,3.0.2:3.0', type=('build', 'run'), when='@6:')

--- a/repos/backport/packages/py-jupyterlab-widgets/package.py
+++ b/repos/backport/packages/py-jupyterlab-widgets/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyJupyterlabWidgets(PythonPackage):
+    """A JupyterLab extension."""
+
+    homepage = "https://github.com/jupyter-widgets/ipywidgets"
+    # Source is also available, but I'm having issues getting it to build:
+    # https://github.com/jupyter-widgets/ipywidgets/issues/3324
+    url = "https://files.pythonhosted.org/packages/py3/j/jupyterlab_widgets/jupyterlab_widgets-1.0.2-py3-none-any.whl"
+
+    version('1.1.0', sha256='c2a9bd3789f120f64d73268c066ed3b000c56bc1dda217be5cdc43e7b4ebad3f', expand=False)
+    version('1.0.2', sha256='f5d9efface8ec62941173ba1cffb2edd0ecddc801c11ae2931e30b50492eb8f7', expand=False)
+
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-setuptools@40.8.0:', type='build')
+    # TODO: replace this after concretizer learns how to concretize separate build deps
+    depends_on('py-jupyter-packaging7', type='build')
+    # depends_on('py-jupyter-packaging@0.7.9:0.7', type='build')
+    depends_on('py-jupyterlab@3.0:3', type='build')


### PR DESCRIPTION
The PRs I opened to add the newer versions of `py-avro`, `py-awkward`, `py-fonttools`, `py-frozenlist`, `py-ipywidgets`, `py-jupyter-console` and `py-jupyterlab-widgets` in `spack/spack` have been approved. Therefore, I backport the missing packages/versions to our repo.
Can I also add them to `spack.yaml`? 