### PR TITLE
Backport newer versions of py-packages (follow-up)

### DIFF
--- a/environments/CMSSW_12_1_X/spack.yaml
+++ b/environments/CMSSW_12_1_X/spack.yaml
@@ -428,6 +428,7 @@ spack:
   - py-mccabe@0.6.1
   - py-mistune@0.8.4
   - py-mock@4.0.3
+  - py-more-itertools@8.12.0
   - py-mpld3@0.5.5
   - py-mplhep@0.3.15
   - py-mplhep-data@0.0.3
@@ -439,6 +440,7 @@ spack:
   - py-nbconvert@6.2.0
   - py-nbformat@5.1.3
   - py-nest-asyncio@1.5.1
+  - py-networkx@2.7.1
   - py-neurolab@0.3.5
   - py-notebook@6.4.5
   - py-numba@0.54.0
@@ -462,12 +464,16 @@ spack:
   - py-pickleshare@0.7.5
   - py-pkgconfig@1.5.5
   - py-pkginfo@1.7.1
+  - py-plac@1.3.5
   - py-ply@3.11
   - py-pillow@8.0.0
   - py-pip@21.3.1
   - py-platformdirs@2.4.0
   - py-pluggy@1.0.0
-  - py-prompt-toolkit@3.0.24
+  - py-poetry@1.1.13
+  - py-poetry-core@1.0.8
+  - py-prettytable@3.2.0
+  - py-prompt-toolkit@3.0.29
   - py-prometheus-client@0.12.0
   - py-protobuf@3.15.1
   - py-psutil@5.8.0
@@ -488,6 +494,7 @@ spack:
   - py-pygithub@1.55
   - py-pygments@2.10.0
   - py-pylev@1.4.0
+  - py-pylint@2.13.5
   - py-pymongo@3.12.1
   - py-pyparsing@2.4.7
   - py-pyrsistent@0.18.0

--- a/repos/backport/packages/py-more-itertools/package.py
+++ b/repos/backport/packages/py-more-itertools/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyMoreItertools(PythonPackage):
+    """Additions to the standard Python itertools package."""
+
+    homepage = "https://github.com/erikrose/more-itertools"
+    pypi = "more-itertools/more-itertools-7.2.0.tar.gz"
+
+    version('8.12.0', sha256='7dc6ad46f05f545f900dd59e8dfb4e84a4827b97b3cfecb175ea0c7d247f6064')
+    version('8.11.0', sha256='0a2fd25d343c08d7e7212071820e7e7ea2f41d8fb45d6bc8a00cd6ce3b7aab88')
+    version('8.9.0',  sha256='8c746e0d09871661520da4f1241ba6b908dc903839733c8203b552cffaf173bd')
+    version('7.2.0',  sha256='409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832')
+    version('7.0.0',  sha256='c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a')
+    version('5.0.0',  sha256='38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4')
+    version('4.3.0',  sha256='c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e')
+    version('4.1.0',  sha256='c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44')
+    version('2.2',    sha256='93e62e05c7ad3da1a233def6731e8285156701e3419a5fe279017c429ec67ce0')
+
+    # https://github.com/more-itertools/more-itertools/issues/578
+    depends_on('python@3.6:', when='@8.11', type=('build', 'run'))
+    depends_on('python@3.5:', when='@7.1:', type=('build', 'run'))
+    depends_on('python@3.4:', when='@6:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.2:', when='@2.3:', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.2:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-six@1.0.0:1', when='@:5', type=('build', 'run'))

--- a/repos/backport/packages/py-networkx/package.py
+++ b/repos/backport/packages/py-networkx/package.py
@@ -1,0 +1,44 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyNetworkx(PythonPackage):
+    """NetworkX is a Python package for the creation, manipulation, and study
+    of the structure, dynamics, and functions of complex networks."""
+
+    homepage = "https://networkx.github.io/"
+    pypi = "networkx/networkx-2.4.tar.gz"
+
+    version('2.7.1', sha256='d1194ba753e5eed07cdecd1d23c5cd7a3c772099bd8dbd2fea366788cf4de7ba')
+    version('2.6.3', sha256='c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51')
+    version('2.5.1', sha256='109cd585cac41297f71103c3c42ac6ef7379f29788eb54cb751be5a663bb235a')
+    version('2.4',  sha256='f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64')
+    version('2.3',  sha256='8311ddef63cf5c5c5e7c1d0212dd141d9a1fe3f474915281b73597ed5f1d4e3d')
+    version('2.2',  sha256='45e56f7ab6fe81652fb4bc9f44faddb0e9025f469f602df14e3b2551c2ea5c8b')
+    version('2.1',  sha256='64272ca418972b70a196cb15d9c85a5a6041f09a2f32e0d30c0255f25d458bb1')
+    version('2.0',  sha256='cd5ff8f75d92c79237f067e2f0876824645d37f017cfffa5b7c9678cae1454aa')
+    version('1.11', sha256='0d0e70e10dfb47601cbb3425a00e03e2a2e97477be6f80638fef91d54dd1e4b8')
+    version('1.10', sha256='ced4095ab83b7451cec1172183eff419ed32e21397ea4e1971d92a5808ed6fb8')
+
+    depends_on('python@2.7:', type=('build', 'run'))
+    depends_on('python@3.5:', type=('build', 'run'), when='@2.3:')
+    depends_on('python@3.6:', type=('build', 'run'), when='@2.5:')
+    depends_on('python@3.7:', type=('build', 'run'), when='@2.6:')
+    depends_on('python@3.8:', type=('build', 'run'), when='@2.7:')
+    depends_on('py-setuptools', type='build')
+    depends_on('py-decorator@3.4.0:', type=('build', 'run'), when='@:1')
+    depends_on('py-decorator@4.1.0:', type=('build', 'run'), when='@2.0:2.1')
+    depends_on('py-decorator@4.3.0:', type=('build', 'run'), when='@2.2:2.4')
+    depends_on('py-decorator@4.3.0:4', type=('build', 'run'), when='@2.5.1:2.5')
+
+    def url_for_version(self, version):
+        ext = 'tar.gz'
+        if Version('2.0') <= version <= Version('2.3'):
+            ext = 'zip'
+
+        url = 'https://pypi.io/packages/source/n/networkx/networkx-{0}.{1}'
+        return url.format(version, ext)

--- a/repos/backport/packages/py-plac/package.py
+++ b/repos/backport/packages/py-plac/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyPlac(PythonPackage):
+    """The smartest command line arguments parser in the world."""
+
+    homepage = "https://github.com/micheles/plac"
+    pypi = "plac/plac-1.1.3.tar.gz"
+
+    # Skip 'plac_tk' imports
+    import_modules = ['plac', 'plac_ext',  'plac_core']
+
+    version('1.3.5', sha256='38bdd864d0450fb748193aa817b9c458a8f5319fbf97b2261151cfc0a5812090')
+    version('1.3.3', sha256='51e332dabc2aed2cd1f038be637d557d116175101535f53eaa7ae854a00f2a74')
+    version('1.1.3', sha256='398cb947c60c4c25e275e1f1dadf027e7096858fb260b8ece3b33bcff90d985f')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-argparse', when='^python@:2.6,3.0:3.1', type=('build', 'run'))

--- a/repos/backport/packages/py-poetry-core/package.py
+++ b/repos/backport/packages/py-poetry-core/package.py
@@ -12,6 +12,7 @@ class PyPoetryCore(PythonPackage):
     homepage = "https://github.com/python-poetry/poetry-core"
     pypi     = "poetry-core/poetry-core-1.0.7.tar.gz"
 
+    version('1.0.8', sha256='951fc7c1f8d710a94cb49019ee3742125039fc659675912ea614ac2aa405b118')
     version('1.0.7', sha256='98c11c755a16ef6c5673c22ca94a3802a7df4746a0853a70b6fae8b9f5cac206')
 
     depends_on('python@2.7,3.5:3', type=('build', 'run'))

--- a/repos/backport/packages/py-poetry/package.py
+++ b/repos/backport/packages/py-poetry/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPoetry(PythonPackage):
+    """Python dependency management and packaging made easy."""
+
+    homepage = "https://python-poetry.org/"
+    pypi     = "poetry/poetry-1.1.12.tar.gz"
+
+    version('1.1.13', sha256='b905ed610085f568aa61574e0e09260c02bff9eae12ff672af39e9f399357ac4')
+    version('1.1.12', sha256='5c66e2357fe37b552462a88b7d31bfa2ed8e84172208becd666933c776252567')
+
+    depends_on('python@2.7,3.5:3', type=('build', 'run'))
+    depends_on('py-poetry-core@1.0.7:1.0', type=('build', 'run'))
+    depends_on('py-cleo@0.8.1:0.8', type=('build', 'run'))
+    depends_on('py-clikit@0.6.2:0.6', type=('build', 'run'))
+    depends_on('py-crashtest@0.3.0:0.3', when='^python@3.6:3', type=('build', 'run'))
+    depends_on('py-requests@2.18:2', type=('build', 'run'))
+    depends_on('py-cachy@0.3.0:0.3', type=('build', 'run'))
+    depends_on('py-requests-toolbelt@0.9.1:0.9', type=('build', 'run'))
+    depends_on('py-cachecontrol@0.12.4:0.12+filecache', when='^python@:3.5', type=('build', 'run'))
+    depends_on('py-cachecontrol@0.12.9:0.12+filecache', when='^python@3.6:3', type=('build', 'run'))
+    depends_on('py-pkginfo@1.4:1', type=('build', 'run'))
+    depends_on('py-html5lib@1.0:1', type=('build', 'run'))
+    depends_on('py-shellingham@1.1:1', type=('build', 'run'))
+    depends_on('py-tomlkit@0.7:0', type=('build', 'run'))
+    depends_on('py-pexpect@4.7:4', type=('build', 'run'))
+    depends_on('py-packaging@20.4:20', type=('build', 'run'))
+    depends_on('py-virtualenv@20.0.26:20', type=('build', 'run'))
+    depends_on('py-typing@3.6:3', when='^python@2.7', type=('build', 'run'))
+    depends_on('py-pathlib2@2.3:2', when='^python@2.7', type=('build', 'run'))
+    depends_on('py-futures@3.3:3', when='^python@2.7', type=('build', 'run'))
+    depends_on('py-glob2@0.6.0:0.6', when='^python@2.7', type=('build', 'run'))
+    depends_on('py-functools32@3.2.3:3', when='^python@2.7', type=('build', 'run'))
+    depends_on('py-keyring@18.0.1:18', when='^python@2.7', type=('build', 'run'))
+    depends_on('py-keyring@20.0.1:20', when='^python@3.5', type=('build', 'run'))
+    depends_on('py-keyring@21.2.0:21', when='@1.1.12 ^python@3.6:3', type=('build', 'run'))
+    depends_on('py-keyring@21.2.0:', when='@1.1.13 ^python@3.6:3', type=('build', 'run'))
+    depends_on('py-subprocess32@3.5:3', when='^python@2.7', type=('build', 'run'))
+    depends_on('py-importlib-metadata@1.6:1', when='^python@:3.7', type=('build', 'run'))

--- a/repos/backport/packages/py-prettytable/package.py
+++ b/repos/backport/packages/py-prettytable/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPrettytable(PythonPackage):
+    """PrettyTable is a simple Python library designed to make
+    it quick and easy to represent tabular data in visually
+    appealing ASCII tables.
+    """
+
+    homepage = "https://github.com/jazzband/prettytable"
+    pypi = "prettytable/prettytable-0.7.2.tar.gz"
+
+    version('3.2.0', sha256='ae7d96c64100543dc61662b40a28f3b03c0f94a503ed121c6fca2782c5816f81')
+    version('2.4.0', sha256='18e56447f636b447096977d468849c1e2d3cfa0af8e7b5acfcf83a64790c0aca')
+    version('0.7.2', sha256='2d5460dc9db74a32bcc8f9f67de68b2c4f4d2f01fa3bd518764c69156d9cacd9')
+
+    depends_on("py-setuptools", type='build')
+    depends_on("py-wcwidth", type=('build', 'run'), when='@2.4.0:')
+    depends_on("py-importlib-metadata", type=('build', 'run'), when='@2.4.0: ^python@:3.7')
+    depends_on("py-setuptools-scm", type='build', when='@2.4.0:')
+    depends_on("python@3.6:", type=('build', 'run'), when='@2.4.0:')
+    depends_on("python@3.7:", type=('build', 'run'), when='@3.2.0:')

--- a/repos/backport/packages/py-prompt-toolkit/package.py
+++ b/repos/backport/packages/py-prompt-toolkit/package.py
@@ -26,6 +26,7 @@ class PyPromptToolkit(PythonPackage):
         'prompt_toolkit.clipboard'
     ]
 
+    version('3.0.29', sha256='bd640f60e8cecd74f0dc249713d433ace2ddc62b65ee07f96d358e0b152b6ea7')
     version('3.0.24', sha256='1bb05628c7d87b645974a1bad3f17612be0c29fa39af9f7688030163f680bad6')
     version('3.0.17', sha256='9397a7162cf45449147ad6042fa37983a081b8a73363a5253dd4072666333137')
     version('3.0.16', sha256='0fa02fa80363844a4ab4b8d6891f62dd0645ba672723130423ca4037b80c1974')

--- a/repos/backport/packages/py-pylint/package.py
+++ b/repos/backport/packages/py-pylint/package.py
@@ -1,0 +1,62 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPylint(PythonPackage):
+    """python code static checker"""
+
+    pypi = "pylint/pylint-1.6.5.tar.gz"
+
+    import_modules = ['pylint', 'pylint.lint', 'pylint.extensions',
+                      'pylint.config', 'pylint.checkers', 'pylint.checkers.refactoring',
+                      'pylint.message', 'pylint.utils', 'pylint.pyreverse',
+                      'pylint.reporters', 'pylint.reporters.ureports']
+
+    version('2.13.5', sha256='dab221658368c7a05242e673c275c488670144123f4bd262b2777249c1c0de9b')
+    version('2.11.1', sha256='2c9843fff1a88ca0ad98a256806c82c5a8f86086e7ccbdb93297d86c3f90c436')
+    version('2.8.2', sha256='586d8fa9b1891f4b725f587ef267abe2a1bad89d6b184520c7f07a253dd6e217')
+    version('2.3.1', sha256='723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1')
+    version('2.3.0', sha256='ee80c7af4f127b2a480d83010c9f0e97beb8eaa652b78c2837d3ed30b12e1182')
+    version('1.9.4', sha256='ee1e85575587c5b58ddafa25e1c1b01691ef172e139fc25585e5d3f02451da93')
+    # version('1.7.2', sha256='ea6afb93a9ed810cf52ff3838eb3a15e2bf6a81b80de0eaede1ce442caa5ca69') # see dependencies
+    version('1.6.5', sha256='a673984a8dd78e4a8b8cfdee5359a1309d833cf38405008f4a249994a8456719')
+    version('1.4.3', sha256='1dce8c143a5aa15e0638887c2b395e2e823223c63ebaf8d5f432a99e44b29f60')
+    version('1.4.1', sha256='3e383060edd432cbbd0e8bd686f5facfe918047ffe1bb401ab5897cb6ee0f030')
+
+    extends('python', ignore=r'bin/pytest')
+    depends_on('python@2.7:2.8,3.4:3.6', when='@:1', type=('build', 'run'))
+    depends_on('python@3.4:', when='@2:2.7', type=('build', 'run'))
+    depends_on('python@3.6:', when='@2.8.2:', type=('build', 'run'))
+    depends_on('python@3.6.2:', when='@2.13.5:', type=('build', 'run'))
+    depends_on('py-astroid', type=('build', 'run'))
+    # note there is no working version of astroid for this
+    depends_on('py-astroid@1.5.1:', type=('build', 'run'), when='@1.7:')
+    depends_on('py-astroid@1.6:1.9', type=('build', 'run'), when='@1.9.4')
+    depends_on('py-astroid@2.0:', type=('build', 'run'), when='@2.2.0:')
+    depends_on('py-astroid@2.2.0:2', type=('build', 'run'), when='@2.3.0:2.7')
+    depends_on('py-astroid@2.5.6:2.6', type=('build', 'run'), when='@2.8.0:2.10')
+    depends_on('py-astroid@2.8.0:2.8', type=('build', 'run'), when='@2.11.1')
+    depends_on('py-astroid@2.11.2:2.11', type=('build', 'run'), when='@2.13.5:')
+    depends_on('py-backports-functools-lru-cache', when='^python@:2.8', type=('build', 'run'))
+    depends_on('py-configparser', when='^python@:2.8', type=('build', 'run'))
+    depends_on('py-dill@0.2:', when='@2.13.5:', type=('build', 'run'))
+    depends_on('py-editdistance', type=('build', 'run'), when='@:1.7')
+    depends_on('py-isort@4.2.5:', type=('build', 'run'))
+    depends_on('py-isort@4.2.5:5', when='@2.3.1:', type=('build', 'run'))
+    depends_on('py-mccabe', type=('build', 'run'))
+    depends_on('py-mccabe@0.6.0:0.6', when='@2.3.1:2.11', type=('build', 'run'))
+    depends_on('py-mccabe@0.6.0:0.7', when='@2.13:', type=('build', 'run'))
+    depends_on('py-pip', type=('build'))  # see https://github.com/spack/spack/issues/27075
+    # depends_on('py-setuptools-scm@1.15.0:', type='build')
+    depends_on('py-setuptools-scm', type='build', when='@2.8.2')
+    depends_on('py-setuptools@17.1:', type='build')
+    depends_on('py-singledispatch', when='^python@:3.3', type=('build', 'run'))
+    depends_on('py-six', type=('build', 'run'), when='@1:2.3.1')
+    depends_on('py-toml@0.7.1:', type=('build', 'run'), when='@2.8.2:2.12.2')
+    depends_on('py-tomli@1.1.0:', type=('build', 'run'), when='@2.13.5: ^python@:3.10')
+    depends_on('py-platformdirs@2.2.0:', type=('build', 'run'), when='@2.11.1:')
+    depends_on('py-typing-extensions@3.10.0:', type=('build', 'run'), when='@2.11.1: ^python@:3.9')


### PR DESCRIPTION
The PRs I opened to add the newer versions of  `py-more-itertools`, `py-netwrokx`, `py-plac`, `py-poetry`, `py-poetry-core`, `py-poetrytable`, `py-prompt-toolkit` and `py-pylint` in `spack/spack` have been approved. Therefore, I backport the missing packages/versions to our repo.